### PR TITLE
Changement de l'emplacement du répertoire de préférences v1.24.2.4973

### DIFF
--- a/plex_update.sh
+++ b/plex_update.sh
@@ -30,7 +30,7 @@ fi
 
 # Recherche de la version de Plex Media Server
 mkdir -p /tmp/plex/ > /dev/null 2>&1
-token=$(cat /volume1/@apphome/PlexMediaServer/Plex\ Media\ Server/Preferences.xml | grep -oP 'PlexOnlineToken="\K[^"]+')
+token=$(cat /volume1/PlexMediaServer/AppData/Plex\ Media\ Server/Preferences.xml | grep -oP 'PlexOnlineToken="\K[^"]+')
 url=$(echo "https://plex.tv/api/downloads/5.json?channel=plexpass&X-Plex-Token=$token")
 jq=$(curl -s ${url})
 newversion=$(echo $jq | jq -r '.nas."Synology (DSM 7)".version')


### PR DESCRIPTION
A partir de la version 1.24.2.4973, l'emplacement du répertoire de préférences change:
(Synology) Use new ‘PlexMediaServer’ share as metadata storage structure on DSM 7

